### PR TITLE
avoids name clashes between kube envs vs app envs

### DIFF
--- a/hypertrace-trace-enricher/src/main/resources/configs/common/application.conf
+++ b/hypertrace-trace-enricher/src/main/resources/configs/common/application.conf
@@ -52,9 +52,9 @@ enricher {
     class = "org.hypertrace.traceenricher.enrichment.enrichers.DefaultServiceEntityEnricher"
     entity.service.config = {
       host = localhost
-      host = ${?ENTITY_SERVICE_HOST}
+      host = ${?ENTITY_SERVICE_HOST_CONFIG}
       port = 50061
-      port = ${?ENTITY_SERVICE_PORT}
+      port = ${?ENTITY_SERVICE_PORT_CONFIG}
     }
     dependencies = ["ApiBoundaryTypeAttributeEnricher"]
   }
@@ -85,9 +85,9 @@ enricher {
     class = "org.hypertrace.traceenricher.enrichment.enrichers.BackendEntityEnricher"
     entity.service.config = {
       host = localhost
-      host = ${?ENTITY_SERVICE_HOST}
+      host = ${?ENTITY_SERVICE_HOST_CONFIG}
       port = 50061
-      port = ${?ENTITY_SERVICE_PORT}
+      port = ${?ENTITY_SERVICE_PORT_CONFIG}
     }
     dependencies = ["DefaultServiceEntityEnricher"]
   }
@@ -106,9 +106,9 @@ enricher {
     dependencies = ["DefaultServiceEntityEnricher", "ApiBoundaryTypeAttributeEnricher"]
     entity.service.config = {
       host = localhost
-      host = ${?ENTITY_SERVICE_HOST}
+      host = ${?ENTITY_SERVICE_HOST_CONFIG}
       port = 50061
-      port = ${?ENTITY_SERVICE_PORT}
+      port = ${?ENTITY_SERVICE_PORT_CONFIG}
     }
   }
 }


### PR DESCRIPTION
- kube sets default env for service port as <service_name>_port e.g ATTRIBUTE_SERVICE_PORT. So, we decided to add _CONFIG` for app-related host/port config to avoid conflicts.