### PR TITLE
Moves to new docker plugin which corrects port defaults and health check

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -3,8 +3,8 @@ plugins {
   id("org.hypertrace.ci-utils-plugin") version "0.1.1"
   id("org.hypertrace.publish-plugin") version "0.3.0" apply false
   id("org.hypertrace.jacoco-report-plugin") version "0.1.0" apply false
-  id("org.hypertrace.docker-java-application-plugin") version "0.4.0" apply false
-  id("org.hypertrace.docker-publish-plugin") version "0.4.0" apply false
+  id("org.hypertrace.docker-java-application-plugin") version "0.5.1" apply false
+  id("org.hypertrace.docker-publish-plugin") version "0.5.1" apply false
 }
 
 subprojects {

--- a/hypertrace-trace-enricher/build.gradle.kts
+++ b/hypertrace-trace-enricher/build.gradle.kts
@@ -15,6 +15,15 @@ application {
   mainClassName = "org.hypertrace.core.serviceframework.PlatformServiceLauncher"
 }
 
+hypertraceDocker {
+  defaultImage {
+    javaApplication {
+      serviceName.set("${project.name}")
+      adminPort.set(8099)
+    }
+  }
+}
+
 // Config for gw run to be able to run this locally. Just execute gw run here on Intellij or on the console.
 tasks.run<JavaExec> {
   jvmArgs = listOf("-Dbootstrap.config.uri=file:${projectDir}/src/main/resources/configs", "-Dservice.name=${project.name}")


### PR DESCRIPTION
was
```
hypertrace-trace-enricher      java -cp /app/resources:/a ...   Up                      8080/tcp
```

now
```
hypertrace-trace-enricher      java -cp /app/resources:/a ...   Up (healthy)            8099/tcp
```