### PR TITLE
Host header enrichment should look at x-forwarded headers when host header is localhost.

### DIFF
--- a/hypertrace-trace-enricher-impl/src/main/java/org/hypertrace/traceenricher/enrichment/enrichers/ApiBoundaryTypeAttributeEnricher.java
+++ b/hypertrace-trace-enricher-impl/src/main/java/org/hypertrace/traceenricher/enrichment/enrichers/ApiBoundaryTypeAttributeEnricher.java
@@ -35,11 +35,20 @@ public class ApiBoundaryTypeAttributeEnricher extends AbstractTraceEnricher {
       EnrichedSpanConstants.getValue(BoundaryTypeValue.BOUNDARY_TYPE_VALUE_ENTRY);
   private static final String EXIT_BOUNDARY_TYPE =
       EnrichedSpanConstants.getValue(BoundaryTypeValue.BOUNDARY_TYPE_VALUE_EXIT);
+  private static final String X_FORWARDED_HOST_SERVER = "x-forwarded-server";
+  private static final String X_FORWARDED_HOST_HEADER = "x-forwarded-host";
+
   private static final List<String> HOST_HEADER_ATTRIBUTES = ImmutableList.of(
+      // The order of these constants is important because that enforces the priority for
+      // different keys/headers.
       RawSpanConstants.getValue(org.hypertrace.core.span.constants.v1.Http.HTTP_REQUEST_HOST_HEADER),
       RawSpanConstants.getValue(org.hypertrace.core.span.constants.v1.Http.HTTP_REQUEST_AUTHORITY_HEADER),
-      RawSpanConstants.getValue(org.hypertrace.core.span.constants.v1.Http.HTTP_HOST)
+      RawSpanConstants.getValue(org.hypertrace.core.span.constants.v1.Http.HTTP_HOST),
+      // In the cases where there are sidecar proxies, the host header might be set to localhost
+      // while the original host will be moved to x-forwarded headers. Hence, read them too.
+      X_FORWARDED_HOST_SERVER, X_FORWARDED_HOST_HEADER
   );
+  private static final String LOCALHOST = "localhost";
 
   @Override
   public void enrichEvent(StructuredTrace trace, Event event) {
@@ -102,10 +111,16 @@ public class ApiBoundaryTypeAttributeEnricher extends AbstractTraceEnricher {
    * enricher class itself could be renamed to be more specific.
    */
   private void enrichHostHeader(Event event) {
-    String host =
-        SpanAttributeUtils.getFirstAvailableStringAttribute(event, HOST_HEADER_ATTRIBUTES);
-    if (host != null) {
-      addEnrichedAttribute(event, HOST_HEADER, AttributeValueCreator.create(sanitizeHostValue(host)));
+    for (String key: HOST_HEADER_ATTRIBUTES) {
+      String value = SpanAttributeUtils.getStringAttribute(event, key);
+      if (value != null && !value.isEmpty()) {
+        // Ignore if it's "localhost"
+        String host = sanitizeHostValue(value);
+        if (!LOCALHOST.equalsIgnoreCase(host)) {
+          addEnrichedAttribute(event, HOST_HEADER, AttributeValueCreator.create(host));
+          break;
+        }
+      }
     }
   }
 

--- a/hypertrace-trace-enricher-impl/src/main/java/org/hypertrace/traceenricher/enrichment/enrichers/ApiBoundaryTypeAttributeEnricher.java
+++ b/hypertrace-trace-enricher-impl/src/main/java/org/hypertrace/traceenricher/enrichment/enrichers/ApiBoundaryTypeAttributeEnricher.java
@@ -35,7 +35,6 @@ public class ApiBoundaryTypeAttributeEnricher extends AbstractTraceEnricher {
       EnrichedSpanConstants.getValue(BoundaryTypeValue.BOUNDARY_TYPE_VALUE_ENTRY);
   private static final String EXIT_BOUNDARY_TYPE =
       EnrichedSpanConstants.getValue(BoundaryTypeValue.BOUNDARY_TYPE_VALUE_EXIT);
-  private static final String X_FORWARDED_HOST_SERVER = "x-forwarded-server";
   private static final String X_FORWARDED_HOST_HEADER = "x-forwarded-host";
 
   private static final List<String> HOST_HEADER_ATTRIBUTES = ImmutableList.of(
@@ -46,7 +45,7 @@ public class ApiBoundaryTypeAttributeEnricher extends AbstractTraceEnricher {
       RawSpanConstants.getValue(org.hypertrace.core.span.constants.v1.Http.HTTP_HOST),
       // In the cases where there are sidecar proxies, the host header might be set to localhost
       // while the original host will be moved to x-forwarded headers. Hence, read them too.
-      X_FORWARDED_HOST_SERVER, X_FORWARDED_HOST_HEADER
+      X_FORWARDED_HOST_HEADER
   );
   private static final String LOCALHOST = "localhost";
 

--- a/hypertrace-trace-enricher-impl/src/test/java/org/hypertrace/traceenricher/enrichment/enrichers/AbstractAttributeEnricherTest.java
+++ b/hypertrace-trace-enricher-impl/src/test/java/org/hypertrace/traceenricher/enrichment/enrichers/AbstractAttributeEnricherTest.java
@@ -28,7 +28,6 @@ import org.hypertrace.core.datamodel.shared.trace.StructuredTraceBuilder;
 import org.hypertrace.core.span.constants.v1.Docker;
 import org.hypertrace.core.span.constants.v1.Envoy;
 import org.hypertrace.core.span.constants.v1.TracerAttribute;
-import org.hypertrace.entity.constants.v1.K8sEntityAttribute;
 import org.hypertrace.entity.constants.v1.ServiceAttribute;
 import org.hypertrace.entity.data.service.client.EntityDataServiceClient;
 import org.hypertrace.entity.data.service.client.EntityDataServiceClientProvider;
@@ -98,27 +97,6 @@ public class AbstractAttributeEnricherTest {
     addEnrichedAttributeToEvent(e, Constants.getEnrichedSpanConstant(SPAN_TYPE),
         AttributeValueCreator.create(Constants.getEnrichedSpanConstant(ENTRY)));
     return e;
-  }
-
-  protected Event.Builder createEventBuilder() {
-    return Event.newBuilder().setCustomerId(TENANT_ID)
-        .setEventId(ByteBuffer.wrap(UUID.randomUUID().toString().getBytes()))
-        .setAttributesBuilder(Attributes.newBuilder().setAttributeMap(new HashMap<>()))
-        .setEnrichedAttributesBuilder(Attributes.newBuilder().setAttributeMap(new HashMap<>()));
-  }
-
-  protected Event.Builder createMockEntryEvent(String cluster, String namespace) {
-    Event.Builder builder = createEventBuilder();
-    builder.getEnrichedAttributesBuilder().getAttributeMap().put(
-        Constants.getEnrichedSpanConstant(SPAN_TYPE),
-        AttributeValueCreator.create(Constants.getEnrichedSpanConstant(ENTRY)));
-    builder.getEnrichedAttributesBuilder().getAttributeMap().put(
-        Constants.getEntityConstant(K8sEntityAttribute.K8S_ENTITY_ATTRIBUTE_CLUSTER_NAME),
-        AttributeValueCreator.create(cluster));
-    builder.getEnrichedAttributesBuilder().getAttributeMap().put(
-        Constants.getEntityConstant(K8sEntityAttribute.K8S_ENTITY_ATTRIBUTE_NAMESPACE_NAME),
-        AttributeValueCreator.create(namespace));
-    return builder;
   }
 
   StructuredTrace createStructuredTrace(String tenantId, Event... events) {


### PR DESCRIPTION
This would help to identify correct host in the case of sidecar deployments because sidecar could actually make the call to service instance over `localhost` URL.