### PR TITLE
Look at the default host header for "host" value when other headers aren't set.

### DIFF
--- a/hypertrace-trace-enricher-impl/src/main/java/org/hypertrace/traceenricher/enrichment/enrichers/ApiBoundaryTypeAttributeEnricher.java
+++ b/hypertrace-trace-enricher-impl/src/main/java/org/hypertrace/traceenricher/enrichment/enrichers/ApiBoundaryTypeAttributeEnricher.java
@@ -37,12 +37,14 @@ public class ApiBoundaryTypeAttributeEnricher extends AbstractTraceEnricher {
       EnrichedSpanConstants.getValue(BoundaryTypeValue.BOUNDARY_TYPE_VALUE_EXIT);
   private static final String X_FORWARDED_HOST_HEADER = "x-forwarded-host";
 
+  private static final String DEFAULT_HOST_HEADER = "host";
   private static final List<String> HOST_HEADER_ATTRIBUTES = ImmutableList.of(
       // The order of these constants is important because that enforces the priority for
       // different keys/headers.
       RawSpanConstants.getValue(org.hypertrace.core.span.constants.v1.Http.HTTP_REQUEST_HOST_HEADER),
       RawSpanConstants.getValue(org.hypertrace.core.span.constants.v1.Http.HTTP_REQUEST_AUTHORITY_HEADER),
       RawSpanConstants.getValue(org.hypertrace.core.span.constants.v1.Http.HTTP_HOST),
+      DEFAULT_HOST_HEADER,
       // In the cases where there are sidecar proxies, the host header might be set to localhost
       // while the original host will be moved to x-forwarded headers. Hence, read them too.
       X_FORWARDED_HOST_HEADER

--- a/hypertrace-trace-enricher-impl/src/test/java/org/hypertrace/traceenricher/enrichment/enrichers/ApiBoundaryTypeAttributeEnricherTest.java
+++ b/hypertrace-trace-enricher-impl/src/test/java/org/hypertrace/traceenricher/enrichment/enrichers/ApiBoundaryTypeAttributeEnricherTest.java
@@ -138,6 +138,13 @@ public class ApiBoundaryTypeAttributeEnricherTest extends AbstractAttributeEnric
 
   @Test
   public void testEnrichEventWithHostHeader() {
+    addEnrichedAttributeToEvent(innerEntrySpan, "host", AttributeValueCreator.create("testHost"));
+    target.enrichEvent(trace, innerEntrySpan);
+    Assertions.assertEquals(EnrichedSpanUtils.getHostHeader(innerEntrySpan), "testHost");
+  }
+
+  @Test
+  public void testEnrichEventWithHttpHostHeader() {
     addEnrichedAttributeToEvent(innerEntrySpan,
         RawSpanConstants.getValue(org.hypertrace.core.span.constants.v1.Http.HTTP_HOST),
         AttributeValueCreator.create("testHost"));


### PR DESCRIPTION
The most basic way host header is set is with 'host' header, which is
not being handled as of now. Added that as the default host header in this change.