### PR TITLE
Bugfix in JDBC backend resolver to parse URLs without failure.

### DIFF
--- a/hypertrace-trace-enricher-impl/build.gradle.kts
+++ b/hypertrace-trace-enricher-impl/build.gradle.kts
@@ -18,7 +18,7 @@ dependencies {
   implementation("org.hypertrace.core.serviceframework:platform-metrics:0.1.9")
 
   implementation("com.typesafe:config:1.4.0")
-  implementation("org.apache.httpcomponents:httpclient:4.5.12")
+  implementation("org.apache.httpcomponents:httpclient:4.5.13")
   implementation("org.apache.commons:commons-lang3:3.10")
   implementation("org.slf4j:slf4j-api:1.7.30")
   implementation("net.sf.uadetector:uadetector-resources:2014.10")

--- a/hypertrace-trace-enricher-impl/src/main/java/org/hypertrace/traceenricher/enrichment/enrichers/resolver/backend/JdbcBackendResolver.java
+++ b/hypertrace-trace-enricher-impl/src/main/java/org/hypertrace/traceenricher/enrichment/enrichers/resolver/backend/JdbcBackendResolver.java
@@ -2,7 +2,10 @@ package org.hypertrace.traceenricher.enrichment.enrichers.resolver.backend;
 
 import static org.hypertrace.traceenricher.util.EnricherUtil.createAttributeValue;
 
+import com.google.common.base.Splitter;
+import com.google.common.util.concurrent.RateLimiter;
 import java.net.URI;
+import java.util.List;
 import java.util.Optional;
 import org.apache.commons.lang3.StringUtils;
 import org.hypertrace.core.datamodel.Event;
@@ -23,6 +26,8 @@ public class JdbcBackendResolver extends AbstractBackendResolver {
   private static final Logger LOGGER = LoggerFactory.getLogger(JdbcBackendResolver.class);
   private static final String JDBC_EVENT_PREFIX = "jdbc";
   private static final String SQL_URL_ATTR = RawSpanConstants.getValue(Sql.SQL_SQL_URL);
+  private static final RateLimiter INVALID_BACKEND_URL_LIMITER = RateLimiter.create(1 / 60d);
+  private static final Splitter COLON_SPLITTER = Splitter.on(":");
 
   public JdbcBackendResolver(FQNResolver fqnResolver) {
     super(fqnResolver);
@@ -40,23 +45,45 @@ public class JdbcBackendResolver extends AbstractBackendResolver {
         return Optional.empty();
       }
 
-      final String revisedBackendUriStr = backendUriStr.replaceFirst("^jdbc:", "");
-      URI backendURI = URI.create(revisedBackendUriStr);
-      String path = backendURI.getPath();
-      String dbScheme = backendURI.getScheme();
-      backendUriStr = String.format("%s:%d", backendURI.getHost(), backendURI.getPort());
+      // Split the URL based on two slashes to extract the host and port values.
+      String[] parts = backendUriStr.split("//");
+      String dbType;
+      if (parts.length > 1) {
+        backendUriStr = JDBC_EVENT_PREFIX + "://" + parts[1];
+        dbType = getDbType(parts[0]);
+      } else {
+        dbType = JDBC_EVENT_PREFIX;
+      }
+
+      String path = null;
+      try {
+        URI backendURI = URI.create(backendUriStr);
+        path = backendURI.getPath();
+        if (backendURI.getHost() != null) {
+          backendUriStr = String.format("%s:%d", backendURI.getHost(), backendURI.getPort());
+        }
+      } catch (Exception e) {
+        if (INVALID_BACKEND_URL_LIMITER.tryAcquire()) {
+          LOGGER.warn("Could not parse the jdbc URL: {}", backendUriStr, e);
+        }
+      }
+
       final Builder entityBuilder = getBackendEntityBuilder(BackendType.JDBC, backendUriStr, event);
       if (StringUtils.isNotEmpty(path)) {
         entityBuilder.putAttributes(
             EntityConstants.getValue(BackendAttribute.BACKEND_ATTRIBUTE_PATH), createAttributeValue(path));
       }
-      if (StringUtils.isNotEmpty(dbScheme)) {
-        entityBuilder
-            .putIdentifyingAttributes(RawSpanConstants.getValue(Sql.SQL_DB_TYPE),
-                createAttributeValue(dbScheme));
-      }
+      entityBuilder.putIdentifyingAttributes(RawSpanConstants.getValue(Sql.SQL_DB_TYPE),
+          createAttributeValue(dbType));
       return Optional.of(entityBuilder.build());
     }
     return Optional.empty();
+  }
+
+  private String getDbType(String scheme) {
+    List<String> parts = COLON_SPLITTER.splitToList(scheme);
+    // If there is more than one parts, returns the second one as the DB type. If not,
+    // default to "jdbc", which is the first part.
+    return parts.size() > 1 ? parts.get(1) : parts.get(0);
   }
 }

--- a/hypertrace-trace-enricher-impl/src/test/java/org/hypertrace/traceenricher/enrichment/enrichers/resolver/backend/JdbcBackendResolverTest.java
+++ b/hypertrace-trace-enricher-impl/src/test/java/org/hypertrace/traceenricher/enrichment/enrichers/resolver/backend/JdbcBackendResolverTest.java
@@ -1,0 +1,98 @@
+package org.hypertrace.traceenricher.enrichment.enrichers.resolver.backend;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+
+import java.nio.ByteBuffer;
+import java.util.Arrays;
+import java.util.Map;
+import org.hypertrace.core.datamodel.AttributeValue;
+import org.hypertrace.core.datamodel.Attributes;
+import org.hypertrace.core.datamodel.Event;
+import org.hypertrace.core.datamodel.EventRef;
+import org.hypertrace.core.datamodel.EventRefType;
+import org.hypertrace.core.datamodel.MetricValue;
+import org.hypertrace.core.datamodel.Metrics;
+import org.hypertrace.core.datamodel.shared.StructuredTraceGraph;
+import org.hypertrace.core.span.constants.v1.Sql;
+import org.hypertrace.entity.constants.v1.BackendAttribute;
+import org.hypertrace.entity.constants.v1.K8sEntityAttribute;
+import org.hypertrace.entity.data.service.client.EntityDataServiceClient;
+import org.hypertrace.entity.data.service.v1.Entity;
+import org.hypertrace.entity.service.constants.EntityConstants;
+import org.hypertrace.traceenricher.enrichedspan.constants.v1.Backend;
+import org.hypertrace.traceenricher.enrichment.enrichers.BackendType;
+import org.hypertrace.traceenricher.enrichment.enrichers.resolver.FQNResolver;
+import org.hypertrace.traceenricher.util.Constants;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Unit tests for {@link JdbcBackendResolver}
+ */
+public class JdbcBackendResolverTest {
+  private EntityDataServiceClient edsClient;
+
+  private JdbcBackendResolver jdbcBackendResolver;
+  private StructuredTraceGraph structuredTraceGraph;
+
+  @BeforeEach
+  public void setup() {
+    jdbcBackendResolver = new JdbcBackendResolver(new FQNResolver(edsClient));
+    edsClient = mock(EntityDataServiceClient.class);
+    structuredTraceGraph = mock(StructuredTraceGraph.class);
+  }
+
+  @Test
+  public void testWebgoatUrl() {
+    Event e = Event.newBuilder().setCustomerId("__default")
+        .setEventId(ByteBuffer.wrap("bdf03dfabf5c70f8".getBytes()))
+        .setEntityIdList(Arrays.asList("4bfca8f7-4974-36a4-9385-dd76bf5c8824")).setEnrichedAttributes(
+            Attributes.newBuilder().setAttributeMap(
+                Map.of("SPAN_TYPE", AttributeValue.newBuilder().setValue("EXIT").build())).build())
+        .setAttributes(Attributes.newBuilder().setAttributeMap(Map
+            .of("sql.url", AttributeValue.newBuilder().setValue("jdbc:hsqldb:hsql://dbhost:9001/webgoat").build(),
+                "span.kind", AttributeValue.newBuilder().setValue("client").build(), "sql.query",
+                AttributeValue.newBuilder()
+                    .setValue("insert into audit_message (message, id) values (?, ?)").build(),
+                "k8s.pod_id",
+                AttributeValue.newBuilder().setValue("55636196-c840-11e9-a417-42010a8a0064").build(),
+                "docker.container_id", AttributeValue.newBuilder()
+                    .setValue("ee85cf2cfc3b24613a3da411fdbd2f3eabbe729a5c86c5262971c8d8c29dad0f").build(),
+                "FLAGS", AttributeValue.newBuilder().setValue("0").build(),
+                Constants.getEntityConstant(K8sEntityAttribute.K8S_ENTITY_ATTRIBUTE_CLUSTER_NAME),
+                AttributeValue.newBuilder().setValue("devcluster").build(),
+                Constants.getEntityConstant(K8sEntityAttribute.K8S_ENTITY_ATTRIBUTE_NAMESPACE_NAME),
+                AttributeValue.newBuilder().setValue("hipstershop").build())).build())
+        .setEventName("jdbc.connection.prepare").setStartTimeMillis(1566869077746L)
+        .setEndTimeMillis(1566869077750L).setMetrics(Metrics.newBuilder()
+            .setMetricMap(Map.of("Duration", MetricValue.newBuilder().setValue(4.0).build())).build())
+        .setEventRefList(Arrays.asList(
+            EventRef.newBuilder().setTraceId(ByteBuffer.wrap("random_trace_id".getBytes()))
+                .setEventId(ByteBuffer.wrap("random_event_id".getBytes()))
+                .setRefType(EventRefType.CHILD_OF).build())).build();
+    final Entity backendEntity = jdbcBackendResolver.resolveEntity(e, structuredTraceGraph).get();
+    assertEquals("dbhost.hipstershop.devcluster:9001", backendEntity.getEntityName());
+    assertEquals(4, backendEntity.getIdentifyingAttributesCount());
+    Assertions.assertEquals(BackendType.JDBC.name(),
+        backendEntity.getIdentifyingAttributesMap().get(Constants.getEntityConstant(
+            BackendAttribute.BACKEND_ATTRIBUTE_PROTOCOL))
+            .getValue().getString());
+    assertEquals("dbhost.hipstershop.devcluster",
+        backendEntity.getIdentifyingAttributesMap().get(Constants.getEntityConstant(BackendAttribute.BACKEND_ATTRIBUTE_HOST)).getValue()
+            .getString());
+    assertEquals("9001",
+        backendEntity.getIdentifyingAttributesMap().get(Constants.getEntityConstant(BackendAttribute.BACKEND_ATTRIBUTE_PORT)).getValue()
+            .getString());
+    assertEquals("hsqldb",
+        backendEntity.getIdentifyingAttributesMap().get(Constants.getRawSpanConstant(Sql.SQL_DB_TYPE)).getValue().getString());
+    assertEquals("jdbc.connection.prepare",
+        backendEntity.getAttributesMap().get(Constants.getEnrichedSpanConstant(Backend.BACKEND_FROM_EVENT)).getValue().getString());
+    assertEquals("62646630336466616266356337306638",
+        backendEntity.getAttributesMap().get(Constants.getEnrichedSpanConstant(Backend.BACKEND_FROM_EVENT_ID)).getValue()
+            .getString());
+    assertEquals("/webgoat",
+        backendEntity.getAttributesMap().get(EntityConstants.getValue(BackendAttribute.BACKEND_ATTRIBUTE_PATH)).getValue().getString());
+  }
+}


### PR DESCRIPTION
Ideally, we should parse the URL separately based on the database
driver type so that we can understand more properties of the datasource. 
See https://www.codejava.net/java-se/jdbc/jdbc-database-connection-url-for-common-databases as an example.
That can come next.