### PR TITLE
Recv/Sent prefix doesn't guarantee protocol GRPC

### DIFF
--- a/hypertrace-trace-enricher-impl/src/main/java/org/hypertrace/traceenricher/enrichment/enrichers/SpanTypeAttributeEnricher.java
+++ b/hypertrace-trace-enricher-impl/src/main/java/org/hypertrace/traceenricher/enrichment/enrichers/SpanTypeAttributeEnricher.java
@@ -189,10 +189,6 @@ public class SpanTypeAttributeEnricher extends AbstractTraceEnricher {
       }
     }
 
-    if (EnricherUtil.isSentGrpcEvent(event) || EnricherUtil.isReceivedGrpcEvent(event)) {
-      return Protocol.PROTOCOL_GRPC;
-    }
-
     // this means, there's no grpc prefix protocol
     if (LOGGER.isDebugEnabled()) {
       LOGGER.debug("Couldn't map the event to any protocol; eventId: {}", event.getEventId());

--- a/hypertrace-trace-enricher-impl/src/test/java/org/hypertrace/traceenricher/enrichment/enrichers/SpanTypeAttributeEnricherTest.java
+++ b/hypertrace-trace-enricher-impl/src/test/java/org/hypertrace/traceenricher/enrichment/enrichers/SpanTypeAttributeEnricherTest.java
@@ -306,13 +306,13 @@ public class SpanTypeAttributeEnricherTest extends AbstractAttributeEnricherTest
   }
 
   @Test
-  public void test_getProtocolNameWithGrpcEventName_noOTandGrpcTags_shouldReturnGrpc() {
+  public void test_getProtocolNameWithGrpcEventName_noOTandGrpcTags_shouldReturnUnspecified() {
     Event e = createEvent(new HashMap<>(), new HashMap<>());
     e.setEventName("Sent./products/browse");
-    Assertions.assertEquals(Protocol.PROTOCOL_GRPC, SpanTypeAttributeEnricher.getProtocolName(e));
+    Assertions.assertEquals(Protocol.PROTOCOL_UNSPECIFIED, SpanTypeAttributeEnricher.getProtocolName(e));
 
     e.setEventName("Recv./products/browse");
-    Assertions.assertEquals(Protocol.PROTOCOL_GRPC, SpanTypeAttributeEnricher.getProtocolName(e));
+    Assertions.assertEquals(Protocol.PROTOCOL_UNSPECIFIED, SpanTypeAttributeEnricher.getProtocolName(e));
   }
 
   @Test


### PR DESCRIPTION
The assumption has been made that if the eventname has
Recv/Sent as prefix, then the protocol is GRPC which
doesn't hold.
We receive OperationName as Recv./cart/checkout in case
of http request.