### PR TITLE
Use URI instead of URL to handle incomplete HTTP URLs in tags

### DIFF
--- a/enriched-span-constants/src/main/java/org/hypertrace/traceenricher/enrichedspan/constants/utils/EnrichedSpanUtils.java
+++ b/enriched-span-constants/src/main/java/org/hypertrace/traceenricher/enrichedspan/constants/utils/EnrichedSpanUtils.java
@@ -301,7 +301,7 @@ public class EnrichedSpanUtils {
     return Optional.empty();
   }
 
-  public static Optional<String> getFullHttpUrl(Event event) {
+  public static Optional<String> getHttpUrl(Event event) {
     if (event.getHttp() != null && event.getHttp().getRequest() != null) {
       return Optional.ofNullable(event.getHttp().getRequest().getUrl());
     }

--- a/enriched-span-constants/src/test/java/org/hypertrace/traceenricher/enrichedspan/constants/utils/EnrichedSpanUtilsTest.java
+++ b/enriched-span-constants/src/test/java/org/hypertrace/traceenricher/enrichedspan/constants/utils/EnrichedSpanUtilsTest.java
@@ -237,7 +237,7 @@ public class EnrichedSpanUtilsTest {
             .build()
     );
 
-    Optional<String> url = EnrichedSpanUtils.getFullHttpUrl(e);
+    Optional<String> url = EnrichedSpanUtils.getHttpUrl(e);
     assertFalse(url.isEmpty());
     assertEquals("http://hipstershop.com?order=1", url.get());
   }
@@ -246,7 +246,7 @@ public class EnrichedSpanUtilsTest {
   public void should_getNullUrl_noHttpFields() {
     Event e = mock(Event.class);
 
-    Optional<String> url = EnrichedSpanUtils.getFullHttpUrl(e);
+    Optional<String> url = EnrichedSpanUtils.getHttpUrl(e);
     assertTrue(url.isEmpty());
   }
 

--- a/hypertrace-trace-enricher-impl/src/main/java/org/hypertrace/traceenricher/enrichment/enrichers/HttpAttributeEnricher.java
+++ b/hypertrace-trace-enricher-impl/src/main/java/org/hypertrace/traceenricher/enrichment/enrichers/HttpAttributeEnricher.java
@@ -38,7 +38,7 @@ public class HttpAttributeEnricher extends AbstractTraceEnricher {
 
   @Override
   public void enrichEvent(StructuredTrace trace, Event event) {
-    String urlString = EnrichedSpanUtils.getFullHttpUrl(event).orElse(null);
+    String urlString = EnrichedSpanUtils.getHttpUrl(event).orElse(null);
     if (urlString != null) {
       URI uri = null;
       try {

--- a/hypertrace-trace-enricher-impl/src/main/java/org/hypertrace/traceenricher/enrichment/enrichers/SpanTypeAttributeEnricher.java
+++ b/hypertrace-trace-enricher-impl/src/main/java/org/hypertrace/traceenricher/enrichment/enrichers/SpanTypeAttributeEnricher.java
@@ -18,7 +18,6 @@ import org.hypertrace.traceenricher.enrichedspan.constants.v1.CommonAttribute;
 import org.hypertrace.traceenricher.enrichedspan.constants.v1.Protocol;
 import org.hypertrace.traceenricher.enrichment.AbstractTraceEnricher;
 import org.hypertrace.traceenricher.util.Constants;
-import org.hypertrace.traceenricher.util.EnricherUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -202,7 +201,7 @@ public class SpanTypeAttributeEnricher extends AbstractTraceEnricher {
     Map<String, AttributeValue> attributeMap = event.getAttributes().getAttributeMap();
 
     // Try to check whether HTTP or HTTPS based on full URL.
-    String fullUrl = EnrichedSpanUtils.getFullHttpUrl(event).orElse(null);
+    String fullUrl = EnrichedSpanUtils.getHttpUrl(event).orElse(null);
     if (fullUrl != null) {
       try {
         URI uri = new URI(fullUrl);

--- a/hypertrace-trace-enricher-impl/src/test/java/org/hypertrace/traceenricher/enrichment/enrichers/HttpAttributeEnricherTest.java
+++ b/hypertrace-trace-enricher-impl/src/test/java/org/hypertrace/traceenricher/enrichment/enrichers/HttpAttributeEnricherTest.java
@@ -196,30 +196,6 @@ public class HttpAttributeEnricherTest extends AbstractAttributeEnricherTest {
   }
 
   @Test
-  public void testDecodeQueryParamsInvalidInput() {
-    //Try putting invalid encoded string in both query param key and value.
-    Event e = createMockEvent();
-    when(e.getHttp())
-        .thenReturn(org.hypertrace.core.datamodel.eventfields.http.Http.newBuilder().setRequest(
-            Request.newBuilder()
-                .setUrl("http://hypertrace.org/users?action=check%!mout&loca%.Ption=hello%3Dworld")
-                .build())
-            .build());
-    enricher.enrichEvent(mockTrace, e);
-
-    //If input is invalid(can't be decoded) the input is returned as it is.
-    AttributeValue actionParam = SpanAttributeUtils.getAttributeValue(e,
-        Constants.getEnrichedSpanConstant(HTTP_REQUEST_QUERY_PARAM) + ".action");
-    assertEquals("check%!mout", actionParam.getValue());
-    assertEquals(List.of("check%!mout"), actionParam.getValueList());
-
-    AttributeValue locationParam = SpanAttributeUtils.getAttributeValue(e,
-        Constants.getEnrichedSpanConstant(HTTP_REQUEST_QUERY_PARAM) + ".loca%.Ption");
-    assertEquals("hello=world", locationParam.getValue());
-    assertEquals(List.of("hello=world"), locationParam.getValueList());
-  }
-
-  @Test
   public void test_withAnInvalidUrl_shouldSkipEnrichment() {
     Event e = createMockEvent();
     Map<String, AttributeValue> avm = e.getAttributes().getAttributeMap();


### PR DESCRIPTION
This is a follow up PR for this PR : https://github.com/hypertrace/span-normalizer/pull/33.

Constructing a `URL` object from `Event -> Http -> Request -> Url` field throws an error in case it is not a full URL(it may only contain the path) but constructing a `URI` object works fine. So, replacing the usage of `URL` by `URI` to handle such cases.