### PR TITLE
Use first class Http fields directly instead of extracting fields out of URL

### DIFF
--- a/hypertrace-trace-enricher-impl/src/main/java/org/hypertrace/traceenricher/enrichment/enrichers/SpanTypeAttributeEnricher.java
+++ b/hypertrace-trace-enricher-impl/src/main/java/org/hypertrace/traceenricher/enrichment/enrichers/SpanTypeAttributeEnricher.java
@@ -18,13 +18,12 @@ import org.hypertrace.traceenricher.enrichedspan.constants.v1.CommonAttribute;
 import org.hypertrace.traceenricher.enrichedspan.constants.v1.Protocol;
 import org.hypertrace.traceenricher.enrichment.AbstractTraceEnricher;
 import org.hypertrace.traceenricher.util.Constants;
-import org.hypertrace.traceenricher.util.EnricherUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nonnull;
-import java.net.URI;
-import java.net.URISyntaxException;
+import java.net.MalformedURLException;
+import java.net.URL;
 import java.util.Map;
 
 /**
@@ -205,12 +204,12 @@ public class SpanTypeAttributeEnricher extends AbstractTraceEnricher {
     String fullUrl = EnrichedSpanUtils.getFullHttpUrl(event).orElse(null);
     if (fullUrl != null) {
       try {
-        URI uri = new URI(fullUrl);
-        Protocol protocol = NAME_TO_PROTOCOL_MAP.get(uri.getScheme().toUpperCase());
+        URL url = new URL(fullUrl);
+        Protocol protocol = NAME_TO_PROTOCOL_MAP.get(url.getProtocol().toUpperCase());
         if (protocol != null) {
           return protocol;
         }
-      } catch (URISyntaxException ignore) {
+      } catch (MalformedURLException ignore) {
         // Ignore these exceptions.
       }
     }

--- a/hypertrace-trace-enricher-impl/src/main/java/org/hypertrace/traceenricher/enrichment/enrichers/resolver/backend/HttpBackendResolver.java
+++ b/hypertrace-trace-enricher-impl/src/main/java/org/hypertrace/traceenricher/enrichment/enrichers/resolver/backend/HttpBackendResolver.java
@@ -3,13 +3,10 @@ package org.hypertrace.traceenricher.enrichment.enrichers.resolver.backend;
 import static org.hypertrace.traceenricher.util.EnricherUtil.createAttributeValue;
 import static org.hypertrace.traceenricher.util.EnricherUtil.setAttributeIfExist;
 
-import java.net.MalformedURLException;
-import java.net.URL;
 import java.util.Optional;
 import org.apache.commons.lang3.StringUtils;
 import org.hypertrace.core.datamodel.Event;
 import org.hypertrace.core.datamodel.eventfields.http.Request;
-import org.hypertrace.core.datamodel.shared.SpanAttributeUtils;
 import org.hypertrace.core.datamodel.shared.StructuredTraceGraph;
 import org.hypertrace.core.span.constants.RawSpanConstants;
 import org.hypertrace.core.span.constants.v1.Http;
@@ -27,9 +24,6 @@ import org.slf4j.LoggerFactory;
 public class HttpBackendResolver extends AbstractBackendResolver {
   private static final Logger LOGGER = LoggerFactory.getLogger(HttpBackendResolver.class);
 
-  private static final String HTTP_HOST_ATTR = RawSpanConstants.getValue(Http.HTTP_HOST);
-  private static final String HTTP_PATH_ATTR = RawSpanConstants.getValue(Http.HTTP_PATH);
-
   public HttpBackendResolver(FQNResolver fqnResolver) {
     super(fqnResolver);
   }
@@ -43,14 +37,6 @@ public class HttpBackendResolver extends AbstractBackendResolver {
               .map(org.hypertrace.core.datamodel.eventfields.http.Http::getRequest);
       String backend = httpRequest.map(Request::getHost).orElse(null);
       String path = httpRequest.map(Request::getPath).orElse(null);
-
-      // if URL string was null or unable to parse URL string, check host attribute
-      if (StringUtils.isEmpty(backend) && SpanAttributeUtils.containsAttributeKey(event, HTTP_HOST_ATTR)) {
-        backend = SpanAttributeUtils.getStringAttribute(event, HTTP_HOST_ATTR);
-        if (SpanAttributeUtils.containsAttributeKey(event, HTTP_PATH_ATTR)) {
-          path = SpanAttributeUtils.getStringAttribute(event, HTTP_PATH_ATTR);
-        }
-      }
 
       if (StringUtils.isEmpty(backend)) {
         // Shouldn't reach here.

--- a/hypertrace-trace-enricher-impl/src/test/java/org/hypertrace/traceenricher/enrichment/enrichers/resolver/backend/BackendEntityResolverTest.java
+++ b/hypertrace-trace-enricher-impl/src/test/java/org/hypertrace/traceenricher/enrichment/enrichers/resolver/backend/BackendEntityResolverTest.java
@@ -82,7 +82,14 @@ public class BackendEntityResolverTest extends AbstractAttributeEnricherTest {
         .setEventRefList(Arrays.asList(
             EventRef.newBuilder().setTraceId(ByteBuffer.wrap("random_trace_id".getBytes()))
                 .setEventId(ByteBuffer.wrap("random_event_id".getBytes()))
-                .setRefType(EventRefType.CHILD_OF).build())).build();
+                .setRefType(EventRefType.CHILD_OF).build()))
+            .setHttp(org.hypertrace.core.datamodel.eventfields.http.Http.newBuilder()
+                    .setRequest(Request.newBuilder()
+                            .setHost("dataservice:9394")
+                            .setPath("/product/5d644175551847d7408760b1")
+                            .build())
+                    .build())
+            .build();
 
     final Entity backendEntity = backendEntityResolver.resolveEntity(e, structuredTraceGraph).get();
     assertEquals(backendEntity.getEntityName(), "dataservice.mypastryshop.devcluster:9394");
@@ -138,10 +145,9 @@ public class BackendEntityResolverTest extends AbstractAttributeEnricherTest {
                 .setRefType(EventRefType.CHILD_OF).build()))
             .setHttp(org.hypertrace.core.datamodel.eventfields.http.Http.newBuilder()
                     .setRequest(Request.newBuilder()
-                            .setUrl("http://dataservice:9394/api/timelines?uri=|%20wget%20https://iplogger.org/1pzQq7")
+                            .setUrl("http://dataservice:9394/product/5d644175551847d7408760b4")
                             .setHost("dataservice:9394")
-                            .setPath("/api/timelines")
-                            .setQueryString("uri=|%20wget%20https://iplogger.org/1pzQq")
+                            .setPath("product/5d644175551847d7408760b4")
                             .build())
                     .build())
             .build();
@@ -194,10 +200,10 @@ public class BackendEntityResolverTest extends AbstractAttributeEnricherTest {
                 .setRefType(EventRefType.CHILD_OF).build()))
             .setHttp(org.hypertrace.core.datamodel.eventfields.http.Http.newBuilder()
                     .setRequest(Request.newBuilder()
-                            .setUrl("http://dataservice:9394/api/timelines?uri=|%20wget%20https://iplogger.org/1pzQq7")
+                            .setUrl("http://dataservice:9394/userreview?productId=5d644175551847d7408760b4")
                             .setHost("dataservice:9394")
-                            .setPath("/api/timelines")
-                            .setQueryString("uri=|%20wget%20https://iplogger.org/1pzQq")
+                            .setPath("/userreview")
+                            .setQueryString("productId=5d644175551847d7408760b4")
                             .build())
                     .build())
             .build();
@@ -252,7 +258,14 @@ public class BackendEntityResolverTest extends AbstractAttributeEnricherTest {
         .setEventRefList(Arrays.asList(
             EventRef.newBuilder().setTraceId(ByteBuffer.wrap("random_trace_id".getBytes()))
                 .setEventId(ByteBuffer.wrap("random_event_id".getBytes()))
-                .setRefType(EventRefType.CHILD_OF).build())).build();
+                .setRefType(EventRefType.CHILD_OF).build()))
+            .setHttp(org.hypertrace.core.datamodel.eventfields.http.Http.newBuilder()
+                    .setRequest(Request.newBuilder()
+                            .setHost("dataservice:9394")
+                            .setPath("/product/5d644175551847d7408760b1")
+                            .build())
+                    .build())
+            .build();
 
     final Entity backendEntity = backendEntityResolver.resolveEntity(e, structuredTraceGraph).get();
     assertEquals(backendEntity.getEntityName(), "dataservice.mypastryshop.devcluster:9394");
@@ -362,7 +375,16 @@ public class BackendEntityResolverTest extends AbstractAttributeEnricherTest {
         .setEventRefList(Arrays.asList(
             EventRef.newBuilder().setTraceId(ByteBuffer.wrap("random_trace_id".getBytes()))
                 .setEventId(ByteBuffer.wrap("random_event_id".getBytes()))
-                .setRefType(EventRefType.CHILD_OF).build())).build();
+                .setRefType(EventRefType.CHILD_OF).build()))
+            .setHttp(org.hypertrace.core.datamodel.eventfields.http.Http.newBuilder()
+                    .setRequest(Request.newBuilder()
+                            .setUrl("http://dataservice:9394/api/timelines?uri=|%20wget%20https://iplogger.org/1pzQq7")
+                            .setHost("dataservice:9394")
+                            .setPath("/api/timelines")
+                            .setQueryString("uri=|%20wget%20https://iplogger.org/1pzQq")
+                            .build())
+                    .build())
+            .build();
 
     final Entity backendEntity = backendEntityResolver.resolveEntity(e, structuredTraceGraph).get();
     assertEquals(backendEntity.getEntityName(), "dataservice.mypastryshop.devcluster:9394");

--- a/hypertrace-trace-enricher-impl/src/test/java/org/hypertrace/traceenricher/enrichment/enrichers/resolver/backend/BackendEntityResolverTest.java
+++ b/hypertrace-trace-enricher-impl/src/test/java/org/hypertrace/traceenricher/enrichment/enrichers/resolver/backend/BackendEntityResolverTest.java
@@ -15,6 +15,7 @@ import org.hypertrace.core.datamodel.EventRef;
 import org.hypertrace.core.datamodel.EventRefType;
 import org.hypertrace.core.datamodel.MetricValue;
 import org.hypertrace.core.datamodel.Metrics;
+import org.hypertrace.core.datamodel.eventfields.http.Request;
 import org.hypertrace.core.datamodel.shared.StructuredTraceGraph;
 import org.hypertrace.core.span.constants.v1.Grpc;
 import org.hypertrace.core.span.constants.v1.Http;
@@ -134,7 +135,16 @@ public class BackendEntityResolverTest extends AbstractAttributeEnricherTest {
         .setEventRefList(Arrays.asList(
             EventRef.newBuilder().setTraceId(ByteBuffer.wrap("random_trace_id".getBytes()))
                 .setEventId(ByteBuffer.wrap("random_event_id".getBytes()))
-                .setRefType(EventRefType.CHILD_OF).build())).build();
+                .setRefType(EventRefType.CHILD_OF).build()))
+            .setHttp(org.hypertrace.core.datamodel.eventfields.http.Http.newBuilder()
+                    .setRequest(Request.newBuilder()
+                            .setUrl("http://dataservice:9394/api/timelines?uri=|%20wget%20https://iplogger.org/1pzQq7")
+                            .setHost("dataservice:9394")
+                            .setPath("/api/timelines")
+                            .setQueryString("uri=|%20wget%20https://iplogger.org/1pzQq")
+                            .build())
+                    .build())
+            .build();
 
     final Entity backendEntity = backendEntityResolver.resolveEntity(e, structuredTraceGraph).get();
     assertEquals("dataservice.mypastryshop.devcluster:9394", backendEntity.getEntityName());
@@ -181,7 +191,16 @@ public class BackendEntityResolverTest extends AbstractAttributeEnricherTest {
         .setEventRefList(Arrays.asList(
             EventRef.newBuilder().setTraceId(ByteBuffer.wrap("random_trace_id".getBytes()))
                 .setEventId(ByteBuffer.wrap("random_event_id".getBytes()))
-                .setRefType(EventRefType.CHILD_OF).build())).build();
+                .setRefType(EventRefType.CHILD_OF).build()))
+            .setHttp(org.hypertrace.core.datamodel.eventfields.http.Http.newBuilder()
+                    .setRequest(Request.newBuilder()
+                            .setUrl("http://dataservice:9394/api/timelines?uri=|%20wget%20https://iplogger.org/1pzQq7")
+                            .setHost("dataservice:9394")
+                            .setPath("/api/timelines")
+                            .setQueryString("uri=|%20wget%20https://iplogger.org/1pzQq")
+                            .build())
+                    .build())
+            .build();
 
     final Entity backendEntity = backendEntityResolver.resolveEntity(e, structuredTraceGraph).get();
     assertEquals("dataservice.mypastryshop.devcluster:9394", backendEntity.getEntityName());
@@ -287,7 +306,16 @@ public class BackendEntityResolverTest extends AbstractAttributeEnricherTest {
         .setEventRefList(Arrays.asList(
             EventRef.newBuilder().setTraceId(ByteBuffer.wrap("random_trace_id".getBytes()))
                 .setEventId(ByteBuffer.wrap("random_event_id".getBytes()))
-                .setRefType(EventRefType.CHILD_OF).build())).build();
+                .setRefType(EventRefType.CHILD_OF).build()))
+        .setHttp(org.hypertrace.core.datamodel.eventfields.http.Http.newBuilder()
+                .setRequest(Request.newBuilder()
+                        .setUrl("http://dataservice:9394/api/timelines?uri=|%20wget%20https://iplogger.org/1pzQq7")
+                        .setHost("dataservice:9394")
+                        .setPath("/api/timelines")
+                        .setQueryString("uri=|%20wget%20https://iplogger.org/1pzQq")
+                        .build())
+                .build())
+        .build();
 
     Entity backendEntity = backendEntityResolver.resolveEntity(e, structuredTraceGraph).get();
     assertEquals("dataservice.mypastryshop.devcluster:9394", backendEntity.getEntityName());

--- a/hypertrace-trace-enricher-impl/src/test/java/org/hypertrace/traceenricher/enrichment/enrichers/resolver/backend/BackendEntityResolverTest.java
+++ b/hypertrace-trace-enricher-impl/src/test/java/org/hypertrace/traceenricher/enrichment/enrichers/resolver/backend/BackendEntityResolverTest.java
@@ -1,7 +1,6 @@
 package org.hypertrace.traceenricher.enrichment.enrichers.resolver.backend;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -9,7 +8,6 @@ import com.google.common.collect.ImmutableMap;
 import java.nio.ByteBuffer;
 import java.util.Arrays;
 import java.util.Map;
-import java.util.Optional;
 import org.hypertrace.core.datamodel.AttributeValue;
 import org.hypertrace.core.datamodel.Attributes;
 import org.hypertrace.core.datamodel.Event;
@@ -18,10 +16,8 @@ import org.hypertrace.core.datamodel.EventRefType;
 import org.hypertrace.core.datamodel.MetricValue;
 import org.hypertrace.core.datamodel.Metrics;
 import org.hypertrace.core.datamodel.shared.StructuredTraceGraph;
-import org.hypertrace.core.span.constants.RawSpanConstants;
 import org.hypertrace.core.span.constants.v1.Grpc;
 import org.hypertrace.core.span.constants.v1.Http;
-import org.hypertrace.core.span.constants.v1.JaegerAttribute;
 import org.hypertrace.core.span.constants.v1.Mongo;
 import org.hypertrace.core.span.constants.v1.Sql;
 import org.hypertrace.entity.constants.v1.BackendAttribute;
@@ -264,7 +260,7 @@ public class BackendEntityResolverTest extends AbstractAttributeEnricherTest {
   }
 
   @Test
-  public void checkBackendEntityGeneratedFromHttpEventUrlWithIllegalCharacter() {
+  public void checkBackendEntityGeneratedFromHttpEventUrlWithIllegalQueryCharacter() {
     Event e = Event.newBuilder().setCustomerId("__default")
         .setEventId(ByteBuffer.wrap("bdf03dfabf5c70f8".getBytes()))
         .setEntityIdList(Arrays.asList("4bfca8f7-4974-36a4-9385-dd76bf5c8824"))
@@ -293,8 +289,21 @@ public class BackendEntityResolverTest extends AbstractAttributeEnricherTest {
                 .setEventId(ByteBuffer.wrap("random_event_id".getBytes()))
                 .setRefType(EventRefType.CHILD_OF).build())).build();
 
-    Optional<Entity> backendEntity = backendEntityResolver.resolveEntity(e, structuredTraceGraph);
-    assertTrue(backendEntity.isEmpty());
+    Entity backendEntity = backendEntityResolver.resolveEntity(e, structuredTraceGraph).get();
+    assertEquals("dataservice.mypastryshop.devcluster:9394", backendEntity.getEntityName());
+    assertEquals(3, backendEntity.getIdentifyingAttributesCount());
+    assertEquals("HTTP", backendEntity.getIdentifyingAttributesMap()
+            .get(Constants.getEntityConstant(BackendAttribute.BACKEND_ATTRIBUTE_PROTOCOL)).getValue().getString());
+    assertEquals("dataservice.mypastryshop.devcluster", backendEntity.getIdentifyingAttributesMap()
+            .get(Constants.getEntityConstant(BackendAttribute.BACKEND_ATTRIBUTE_HOST)).getValue().getString());
+    assertEquals("9394", backendEntity.getIdentifyingAttributesMap()
+            .get(Constants.getEntityConstant(BackendAttribute.BACKEND_ATTRIBUTE_PORT)).getValue().getString());
+    assertEquals("egress_http", backendEntity.getAttributesMap()
+            .get(Constants.getEnrichedSpanConstant(Backend.BACKEND_FROM_EVENT)).getValue().getString());
+    assertEquals("62646630336466616266356337306638", backendEntity.getAttributesMap()
+            .get(Constants.getEnrichedSpanConstant(Backend.BACKEND_FROM_EVENT_ID)).getValue().getString());
+    assertEquals("GET", backendEntity.getAttributesMap().
+            get(Constants.getRawSpanConstant(Http.HTTP_METHOD)).getValue().getString());
   }
 
   @Test


### PR DESCRIPTION
At some places, we're extracting fields out of HTTP URL but they are already present as first class fields. Not only we're doing extra processing, but this could be error prone as well - like we're using URI to parse the URL string field. The problem with it is that it throws an exception if there are some illegal characters in the query string. These invalid query strings can be potential security threats. However, parsing those string fields with URL object(as done by span-normalizer) works fine. 

So, it is better to use the first class Http fields directly instead of extracting them out of URL.